### PR TITLE
Remove warnings from OpenMP prefetch examples

### DIFF
--- a/Publications/GPU-Opt-Guide/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/CMakeLists.txt
@@ -77,6 +77,13 @@ function(add_example name)
   add_test(NAME ${name} COMMAND ${name} ${ARGN})
 endfunction(add_example)
 
+function(add_openmp_example name)
+  set(_sources ${name}.cpp)
+  add_executable(${name} ${_sources})
+  target_compile_options(${name} PRIVATE ${COMMON_CXX_FLAGS})
+  add_test(NAME ${name} COMMAND ${name} ${ARGN})
+endfunction(add_openmp_example)
+
 function(add_fortran_example name)
   if(CMAKE_Fortran_COMPILER)
     set(_sources ${name}.f90)

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_example(nbody_c)
+add_openmp_example(nbody_c)

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c/nbody_c.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c/nbody_c.cpp
@@ -71,7 +71,7 @@ void nbody_1d_cpu(float *c, float *a, float *b, int n1, int n2) {
 void clean_cache_gpu(double *d, int n) {
 
 #pragma omp target teams distribute parallel for thread_limit(1024)
-  for (unsigned i = 0; i < n; ++i)
+  for (int i = 0; i < n; ++i)
     d[i] = i;
 
   return;

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_compile_options(-fopenmp-target-simd)
-add_example(nbody_c_simd)
+add_openmp_example(nbody_c_simd)

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/nbody_c_simd.cpp
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/c_simd/nbody_c_simd.cpp
@@ -90,7 +90,7 @@ void nbody_1d_cpu(float *c, float *a, float *b, int n1, int n2) {
 void clean_cache_gpu(double *d, int n) {
 
 #pragma omp target teams distribute parallel for thread_limit(1024)
-  for (unsigned i = 0; i < n; ++i)
+  for (int i = 0; i < n; ++i)
     d[i] = i;
 
   return;

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/fortran/CMakeLists.txt
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/fortran/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_compile_options(-fpconstant -fpp -ffast-math -fno-sycl-instrument-device-code)
+add_compile_options(-fpconstant -fpp -ffast-math)
 add_fixed_fortran_example(nbody_f)

--- a/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/fortran/nbody_f.f
+++ b/Publications/GPU-Opt-Guide/OpenMP/26_omp_prefetch/fortran/nbody_f.f
@@ -7,6 +7,8 @@ c snippet-begin
 #define PREFETCH_HINT 4     ! 4 = prefetch to L1 and L3;  2 = prefetch to L3
 #define TILE_SIZE 64
 
+      module gpu_kernels
+      contains
       subroutine nbody_1d_gpu(c, a, b, n1, n2)
       implicit none
       integer n1, n2
@@ -53,7 +55,7 @@ c snippet-end
       implicit none
       integer n1, n2
       real a(0:n1), b(0:n2), c(0:n1)
-      real dx, bb(0:TILE_SIZE), delta, r2, s0, s1, f
+      real dx, delta, r2, s0, s1, f
       integer i,j
       real ma0, ma1, ma2, ma3, ma4, ma5, eps
       parameter (ma0=0.269327, ma1=-0.0750978, ma2=0.0114808)
@@ -86,7 +88,10 @@ c snippet-end
 !$omp end target teams distribute parallel do
       end subroutine
 
+      end module gpu_kernels
+
       program nbody
+      use gpu_kernels
       implicit none
       include 'omp_lib.h'
 


### PR DESCRIPTION
# Existing Sample Changes
## Description

This PR modifies CMake scripts and sources in GPU-opt-guide examples to remove warnings from the examples in 26_omp_prefetch. 


Fixes Issue# 

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Implement fixes for ONSAM Jiras

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Command Line
- [ ] oneapi-cli
- [ ] Visual Studio
- [ ] Eclipse IDE
- [ ] VSCode
- [ ] When compiling the compliler flag "-Wall -Wformat-security -Werror=format-security" was used

**_Delete this line and everything below if this is not a PR for a new code sample_**

**_Delete this line and all above it if this PR is for a new code sample_**
# Adding a New Sample(s)

## Description

Please include a description of the sample

## Checklist
Administrative
- [ ] Review sample design with the appropriate [Domain Expert](https://github.com/oneapi-src/oneAPI-samples/wiki/Reviewers-and-Domain-Experts): <insert Name Here>
- [ ] If you have any new dependencies/binaries, inform the oneAPI Code Samples Project Manager

Code Development
- [ ] Implement coding guidelines and ensure code quality. [see wiki for details](https://github.com/oneapi-src/oneAPI-samples/wiki/General-Code-Guidelines)
- [ ] Adhere to readme template 
- [ ] Enforce format via clang-format config file
- [ ] Adhere to sample.json specification. https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-specification
- [ ] Ensure/create CI test configurations for sample (ciTests field) https://github.com/oneapi-src/oneAPI-samples/wiki/sample-json-ci-test-object
- [ ] Run jsonlint on sample.json to verify json syntax. www.jsonlint.com

Security and Legal
- [ ] OSPDT Approval (see Project Manager for assistance)
- [ ] Compile using the following compiler flags and fix any warnings, the falgs are: "/Wall -Wformat-security -Werror=format-security"
- [ ] Bandit Scans (Python only)
- [ ] Virus scan

Review
- [ ] Review DPC++ code with Paul Peterseon. (GitHub User: pmpeter1)
- [ ] Review readme with Tom Lenth(@tomlenth) and/or Project Manager
- [ ] Tested using Dev Cloud when applicable
